### PR TITLE
Updated PWM frequency functions

### DIFF
--- a/Adafruit_MotorHAT/Adafruit_PWM_Servo_Driver.py
+++ b/Adafruit_MotorHAT/Adafruit_PWM_Servo_Driver.py
@@ -50,13 +50,13 @@ class PWM :
     self.i2c.write8(self.__MODE2, self.__OUTDRV)
     self.i2c.write8(self.__MODE1, self.__ALLCALL)
     time.sleep(0.005)                                       # wait for oscillator
-    
+
     mode1 = self.i2c.readU8(self.__MODE1)
     mode1 = mode1 & ~self.__SLEEP                 # wake up (reset sleep)
     self.i2c.write8(self.__MODE1, mode1)
     time.sleep(0.005)                             # wait for oscillator
 
-  def setPWMFreq(self, freq):
+  def setPWMFreq(self, freq, correctionFactor=1.0):
     "Sets the PWM frequency"
     prescaleval = 25000000.0    # 25MHz
     prescaleval /= 4096.0       # 12-bit
@@ -65,7 +65,7 @@ class PWM :
     if (self.debug):
       print "Setting PWM frequency to %d Hz" % freq
       print "Estimated pre-scale: %d" % prescaleval
-    prescale = math.floor(prescaleval + 0.5)
+    prescale = round(prescaleval * correctionFactor + 0.5)
     if (self.debug):
       print "Final pre-scale: %d" % prescale
 
@@ -76,6 +76,57 @@ class PWM :
     self.i2c.write8(self.__MODE1, oldmode)
     time.sleep(0.005)
     self.i2c.write8(self.__MODE1, oldmode | 0x80)
+
+  def setPWMFreqMin(self, freq, correctionFactor=1.0):
+    "Sets the PWM frequency"
+    prescaleval = 25000000.0    # 25MHz
+    prescaleval /= 4096.0       # 12-bit
+    prescaleval /= float(freq)
+    prescaleval -= 1.0
+    if (self.debug):
+      print "Setting PWM frequency to %d Hz" % freq
+      print "Estimated pre-scale: %d" % prescaleval
+    prescale = math.floor(prescaleval * correctionFactor + 0.5)
+    if (self.debug):
+      print "Final pre-scale: %d" % prescale
+
+    oldmode = self.i2c.readU8(self.__MODE1);
+    newmode = (oldmode & 0x7F) | 0x10             # sleep
+    self.i2c.write8(self.__MODE1, newmode)        # go to sleep
+    self.i2c.write8(self.__PRESCALE, int(math.floor(prescale)))
+    self.i2c.write8(self.__MODE1, oldmode)
+    time.sleep(0.005)
+    self.i2c.write8(self.__MODE1, oldmode | 0x80)
+
+  def setPWMFreqMax(self, freq, correctionFactor=1.0):
+    "Sets the PWM frequency"
+    prescaleval = 25000000.0    # 25MHz
+    prescaleval /= 4096.0       # 12-bit
+    prescaleval /= float(freq)
+    prescaleval -= 1.0
+    if (self.debug):
+      print "Setting PWM frequency to %d Hz" % freq
+      print "Estimated pre-scale: %d" % prescaleval
+    prescale = math.ceil(prescaleval * correctionFactor + 0.5)
+    if (self.debug):
+      print "Final pre-scale: %d" % prescale
+
+    oldmode = self.i2c.readU8(self.__MODE1);
+    newmode = (oldmode & 0x7F) | 0x10             # sleep
+    self.i2c.write8(self.__MODE1, newmode)        # go to sleep
+    self.i2c.write8(self.__PRESCALE, int(math.floor(prescale)))
+    self.i2c.write8(self.__MODE1, oldmode)
+    time.sleep(0.005)
+    self.i2c.write8(self.__MODE1, oldmode | 0x80)
+
+  def getPWMFreq(self):
+    prescale = self.i2c.readU8(self.__PRESCALE)
+    calcfreq = 25000000.0 / 4096.0 / ( float(prescale) + 1 )
+    if (self.debug):
+      print "Got pre-scale: %d" % prescale
+      print "Calculated Frequency: %d" % calcfreq
+
+    return calcfreq
 
   def setPWM(self, channel, on, off):
     "Sets a single PWM channel"


### PR DESCRIPTION
Have been finding some inaccuracies between the requested frequency and the actual one output (when measured) so after some research and looking at others solutions have added the following:

Changed setPWMFreq to use round instead of floor
Added setPWMFreqMin to use floor
Added setPWMFreqMax to use ceil
Added getPWMFreq to return set frequency
Added correctionFactor - defaulted to 1.0 - to all setPWM functions to
allow fine tuning of frequency output.

Correction Factor idea from - https://github.com/johntreacy/adafruit-pca9685/blob/master/adafruit-pca9685.js
PWM Min and Max idea from - https://github.com/emlid/Navio-SDK-experimental/blob/master/src/pca9685.cpp
