### PR TITLE
Reduce i2c traffic, resolve erratic stepper motor pace changes

### DIFF
--- a/Adafruit_MotorHAT/Adafruit_I2C.py
+++ b/Adafruit_MotorHAT/Adafruit_I2C.py
@@ -42,6 +42,7 @@ class Adafruit_I2C(object):
     # self.bus = smbus.SMBus(1); # Force I2C1 (512MB Pi's)
     self.bus = smbus.SMBus(busnum if busnum >= 0 else Adafruit_I2C.getPiI2CBusNumber())
     self.debug = debug
+    self.regvals = [None] * 256
 
   def reverseByteOrder(self, data):
     "Reverses the byte order of an int (16-bit) or long (32-bit) value"
@@ -59,12 +60,14 @@ class Adafruit_I2C(object):
 
   def write8(self, reg, value):
     "Writes an 8-bit value to the specified register/address"
-    try:
-      self.bus.write_byte_data(self.address, reg, value)
-      if self.debug:
-        print "I2C: Wrote 0x%02X to register 0x%02X" % (value, reg)
-    except IOError, err:
-      return self.errMsg()
+    if self.regvals[reg] is None or self.regvals[reg] != value:
+        try:
+          self.bus.write_byte_data(self.address, reg, value)
+          self.regvals[reg] = value
+          if self.debug:
+            print("I2C: Wrote 0x%02X to register 0x%02X" % (value, reg))
+        except IOError as err:
+          return self.errMsg()
 
   def write16(self, reg, value):
     "Writes a 16-bit value to the specified register/address pair"


### PR DESCRIPTION
I experienced some weird behaviour due to the high i2c traffic.
I was driving **stepper motors** and they would go fast then slow then fast 
than slow again in an erratic pattern. Eventually I found a thread on the 
raspberry pi forums, in which a user of the name [pootle](https://www.raspberrypi.org/forums/memberlist.php?mode=viewprofile&u=82688&sid=3d82f3b05eb96688d57d1ba25f8d9a70) [suggested the 
code changes](https://www.raspberrypi.org/forums/viewtopic.php?f=45&t=130475#p987541) introduced with this commit to reduce the i2c traffic in 
order to reach a higher throughput.

Optimising that i2c traffic resolved my stepper motor issues completely, 
removing the erratic pace changes I was seeing.
