### PR TITLE
Fix bug: no raise IOError

### DIFF
--- a/Adafruit_MotorHAT/Adafruit_I2C.py
+++ b/Adafruit_MotorHAT/Adafruit_I2C.py
@@ -54,7 +54,8 @@ class Adafruit_I2C(object):
     return val
 
   def errMsg(self):
-    print "Error accessing 0x%02X: Check your I2C address" % self.address
+    #print "Error accessing 0x%02X: Check your I2C address" % self.address
+    raise IOError("Error accessing 0x%02X: Check your I2C address " % self.address)
     return -1
 
   def write8(self, reg, value):


### PR DESCRIPTION
Changed: (2 lines of code) in Adafruit_MotorHAT/Adafruit_I2C.py in errMsg() the print statement was changed to a raise IOError (same message put here) This error message is called when a nonexistent Hat is accessed.

Limitations: if the Hat the developer is trying to access does not actually exist, the print statement would go along it's jolly way, but the raise will now kill the program if it is not caught with an except -- which is appropriate. If the Hat is not installed, it probably shouldn't go along its jolly way.

Tests: I am catching this exception in my code, and now it catches nicely. When I do not catch the error, it stops execution with the IOError and message.
